### PR TITLE
Protobuf File Structure and Support in Test Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ _Note: If you are on a Windows PC, use WSL2 (look up install instructions, ubunt
 
     - Windows + WSL2: [usbipd-win](https://learn.microsoft.com/en-us/windows/wsl/connect-usb) - This is used to expose the USB ports to WSL2 so that flashing works properly
 
+    - [Protobuf compiler](https://protobuf.dev/installation/) 
+        - If using WSL/Ubuntu: `sudo apt install -y protobuf-compiler`
+
 2. Clone this repository:
     ```bash
     git clone git@github.com:embedded-purdue/slayterHIL.git

--- a/shared/proto/README.md
+++ b/shared/proto/README.md
@@ -1,0 +1,66 @@
+# Using Protobuf
+
+We use protobuf to standardize our data packets between different devices. The format of packets is defined in this folder, in .proto files. When each application is built, the .proto files get compiled into files of the appropriate language. 
+
+For example, a .proto file that looks like this:
+
+```protobuf
+// protobuf - "example.proto"
+syntax = "proto3";
+
+message Example {
+    int32 val = 1;
+}
+```
+
+Will generate a file that looks something like this:
+
+```C
+// C - "example.pb.h"
+typdef struct {
+    uint32_t val;
+} Example;
+```
+or
+```Cpp
+// C++ - "example.pb.h"
+class Example {
+  private:
+    uint32_t val;
+  public:
+    uint32_t val();
+    void set_val();
+}
+```
+
+In every language, protobuf libraries provide ways to encode and decode these messages so that they have a predictable binary representation. This is why protobuf is useful: we don't have to worry about consistent padding and ordering of struct information, and we only have to define data types once.
+
+# Using Protobuf with C (test_node / zephyr):
+
+We use the [nanopb](https://jpa.kapsi.fi/nanopb/) library, which is integrated with zephyr. This is enabled in west.yml and prj.conf files.
+
+
+When compiling, ensure protobuf compiler is installed and west workspace is updated (see project README):
+```bash
+`sudo apt install -y protobuf-compiler`
+`west update`
+`west packages pip --install`
+```
+
+
+To use protobuf definitions in your code:
+1. Include associated proto file header
+    * `#include "example.pb.h" // Contains definitions for all messages and enums in "example.proto"`
+2. Include encode / decode header
+    * For encoding: `#include <pb_encode.h>`
+    * For decoding: `#include <pb_decode.h>`
+3. Encode / decode messages 
+    * Great example in `zephyr/samples/modules/nanopb`
+    * Also look through nanopb documentation and utilize llm
+
+Tips:
+* To get autocomplete/intellisense with new protobuf definitions, you should build the project first to generate the .pb.h and .pb.c files. These will exist in the test_node/build directory.
+
+# Using Protobuf with C++ (flight sim)
+1. install protobuf 
+    * `sudo apt install -y protobuf-compiler`

--- a/shared/proto/example.proto
+++ b/shared/proto/example.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Example {
+    int32 val = 1; // 1 is just the ID of "val" field. The actual value can be any 32-bit integer.
+}

--- a/test_node/.west/west.yml
+++ b/test_node/.west/west.yml
@@ -35,6 +35,7 @@ manifest:
         # strictly needed by the application.
         name-allowlist:
           - hal_espressif # required for ESP32-based boards
+          - nanopb # protobuf
 
   self:
     path: zephyr

--- a/test_node/app/CMakeLists.txt
+++ b/test_node/app/CMakeLists.txt
@@ -11,3 +11,10 @@ project(my_zephyr_app)
 project(app LANGUAGES C)
 
 target_sources(app PRIVATE src/main.c)
+
+# Protobuf
+list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/modules/nanopb)
+include(nanopb)
+
+FILE(GLOB proto_sources ${CMAKE_CURRENT_SOURCE_DIR}/../../shared/proto/*.proto)
+zephyr_nanopb_sources(app ${proto_sources})

--- a/test_node/app/prj.conf
+++ b/test_node/app/prj.conf
@@ -4,3 +4,4 @@
 # This file contains selected Kconfig options for the application.
 
 CONFIG_SENSOR=y
+CONFIG_NANOPB=y


### PR DESCRIPTION
## Description
Created shared/proto file for protobuf definitions, and enabled nanopb in test node zephyr project. Added instructions to the main repo readme and the shared/proto/readme.

Link to Issue: #44 
---

## Checklist
<!-- Make sure the PR is ready for review. -->

- [x] Code follows the project’s style guidelines  

---