### PR TITLE
Add command to justfile that attaches connection to WSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv
+.idea

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ _Note: If you are on a Windows PC, use WSL2 (look up install instructions, ubunt
 8. Test flash
     1. navigate to `slayterHIL/test_node/zephyr`
     3. (FOR WSL USERS; SKIP IF NOT) plug in board and use usbipd to connect it
+       0. as a shortcut, try using `just attach-wsl-usb-port`. This should work as long as your laptop is directly plugged into the UART port on the esp32
        1. on Powershell (run with admin), run `usbipd list` and find the busid for the MCU
 
           *example output:*

--- a/test_node/justfile
+++ b/test_node/justfile
@@ -52,6 +52,26 @@ monitor-esp32:
 
 run-esp32: build-esp32 flash-esp32 monitor-esp32
 
+attach-wsl-usb-port:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  BUSID=$(usbipd.exe list | grep "CP2102N USB to UART Bridge Controller" | awk 'NR==1 {print $1}')
+
+  if [ -z "$BUSID" ]; then
+    echo "Device not found: CP2102N USB to UART Bridge Controller"
+    echo "This error may be because you are using a USB adapter."
+    exit 1
+  fi
+
+  echo "Found device on BUSID: $BUSID"
+
+  usbipd.exe bind --busid "$BUSID"
+  usbipd.exe attach --wsl --busid "$BUSID"
+
+  echo "Device attached to WSL."
+
+
 # ------------------
 #  Defaults
 # ------------------


### PR DESCRIPTION
## Description
Added a justfile command to automatically attach the esp32s3 connection to WSL2. Note that this requires a direct connection between the ESP and the host laptop because the command searches for the name of the UART port on the laptop. This means 

## Screenshots
<img width="1388" height="407" alt="image" src="https://github.com/user-attachments/assets/f62e6dd8-547b-4f52-ab99-21e42c3fb74f" />

## Checklist
- [x] Code follows the project’s style guidelines  
- [x] Successful run that connects the esp32 to wsl

---
