### PR TITLE
Kamila/ta/zephyr build

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -2,7 +2,7 @@ name: CMake Build (Non-Zephyr Components)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -1,0 +1,49 @@
+name: CMake Build (Non-Zephyr Components)
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build CMake Components
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential
+
+    - name: Create build directory
+      run: mkdir -p build
+
+    - name: Configure with CMake
+      run: |
+        if [ -f "flight_controller/CMakeLists.txt" ]; then
+          cmake -B build/flight_controller -S flight_controller -DCMAKE_BUILD_TYPE=Release
+        fi
+        if [ -f "flight_sim/CMakeLists.txt" ]; then
+          cmake -B build/flight_sim -S flight_sim -DCMAKE_BUILD_TYPE=Release
+        fi
+
+    - name: Build the project
+      run: |
+        if [ -d "build/flight_controller" ]; then
+          cmake --build build/flight_controller --config Release
+        fi
+        if [ -d "build/flight_sim" ]; then
+          cmake --build build/flight_sim --config Release
+        fi
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: cmake-build
+        path: build/
+

--- a/.github/workflows/placeholder_windows.yml
+++ b/.github/workflows/placeholder_windows.yml
@@ -28,7 +28,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/zephyr-build.yml
+++ b/.github/workflows/zephyr-build.yml
@@ -1,0 +1,140 @@
+name: Zephyr RTOS Multi-Board Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build for ${{ matrix.board_name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - board_name: qemu_x86
+            board_target: qemu_x86
+          - board_name: esp32s3_devkitc-esp32s3-procpu
+            board_target: esp32s3_devkitc/esp32s3/procpu
+          - board_name: nucleo_f302r8
+            board_target: nucleo_f302r8
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git cmake ninja-build gperf \
+          ccache dfu-util device-tree-compiler wget \
+          python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
+          make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
+
+    - name: Install West
+      run: |
+        pip3 install --user -U west
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Initialize Zephyr workspace
+      run: |
+        west init -m https://github.com/zephyrproject-rtos/zephyr --mr main zephyrproject
+        cd zephyrproject
+        west update
+        west zephyr-export
+
+    - name: Install Zephyr dependencies
+      run: |
+        pip3 install --user -r zephyrproject/zephyr/scripts/requirements.txt
+
+    - name: Set up Zephyr environment
+      run: |
+        cd zephyrproject
+        echo "ZEPHYR_BASE=$PWD/zephyr" >> $GITHUB_ENV
+        echo "$PWD/zephyr/scripts" >> $GITHUB_PATH
+
+    - name: Build for ${{ matrix.board_name }}
+      run: |
+        cd zephyrproject
+        west build -p auto -b "${{ matrix.board_target }}" "$GITHUB_WORKSPACE/test_node/app"
+
+    - name: Upload build artifacts for ${{ matrix.board_name }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: zephyr-build-${{ matrix.board_name }}
+        path: zephyrproject/build/
+
+  test:
+    name: Test on QEMU
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git cmake ninja-build gperf \
+          ccache dfu-util device-tree-compiler wget \
+          python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
+          make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
+
+    - name: Install West
+      run: |
+        pip3 install --user -U west
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Initialize Zephyr workspace
+      run: |
+        west init -m https://github.com/zephyrproject-rtos/zephyr --mr main zephyrproject
+        cd zephyrproject
+        west update
+        west zephyr-export
+
+    - name: Install Zephyr dependencies
+      run: |
+        pip3 install --user -r zephyrproject/zephyr/scripts/requirements.txt
+
+    - name: Set up Zephyr environment
+      run: |
+        cd zephyrproject
+        echo "ZEPHYR_BASE=$PWD/zephyr" >> $GITHUB_ENV
+        echo "$PWD/zephyr/scripts" >> $GITHUB_PATH
+
+    - name: Run QEMU test
+      run: |
+        cd zephyrproject
+        west build -p auto -b qemu_x86 "$GITHUB_WORKSPACE/test_node/app"
+        timeout 30s west build -t run || true
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: ./artifacts
+
+    - name: Create release archive
+      run: |
+        mkdir -p release
+        for artifact in artifacts/zephyr-build-*; do
+          board=$(basename "$artifact" | sed 's/zephyr-build-//')
+          cp -r "$artifact" "release/$board"
+        done
+        tar -czf slayterHIL-firmware.tar.gz -C release .
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: slayterHIL-firmware.tar.gz
+        generate_release_notes: true
+

--- a/.github/workflows/zephyr-build.yml
+++ b/.github/workflows/zephyr-build.yml
@@ -44,10 +44,14 @@ jobs:
         cd zephyrproject
         west update
         west zephyr-export
+        # Install any west-declared python packages (covers some vendor tools)
+        west packages pip --install || true
 
     - name: Install Zephyr dependencies
       run: |
         pip3 install --user -r zephyrproject/zephyr/scripts/requirements.txt
+        # Ensure esptool is available for ESP32 family builds
+        pip3 install --user "esptool>=5.0.2"
 
     - name: Install Zephyr SDK
       env:
@@ -105,10 +109,12 @@ jobs:
         cd zephyrproject
         west update
         west zephyr-export
+        west packages pip --install || true
 
     - name: Install Zephyr dependencies
       run: |
         pip3 install --user -r zephyrproject/zephyr/scripts/requirements.txt
+        pip3 install --user "esptool>=5.0.2"
 
     - name: Install Zephyr SDK
       env:

--- a/.github/workflows/zephyr-build.yml
+++ b/.github/workflows/zephyr-build.yml
@@ -49,6 +49,17 @@ jobs:
       run: |
         pip3 install --user -r zephyrproject/zephyr/scripts/requirements.txt
 
+    - name: Install Zephyr SDK
+      env:
+        SDK_VER: 0.16.5
+      run: |
+        cd "$HOME"
+        wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${SDK_VER}/zephyr-sdk-${SDK_VER}_linux-x86_64.tar.xz
+        tar -xJf zephyr-sdk-${SDK_VER}_linux-x86_64.tar.xz
+        mv zephyr-sdk-${SDK_VER} zephyr-sdk
+        "$HOME/zephyr-sdk/setup.sh" -t all -h
+        echo "ZEPHYR_SDK_INSTALL_DIR=$HOME/zephyr-sdk" >> $GITHUB_ENV
+
     - name: Set up Zephyr environment
       run: |
         cd zephyrproject
@@ -98,6 +109,17 @@ jobs:
     - name: Install Zephyr dependencies
       run: |
         pip3 install --user -r zephyrproject/zephyr/scripts/requirements.txt
+
+    - name: Install Zephyr SDK
+      env:
+        SDK_VER: 0.16.5
+      run: |
+        cd "$HOME"
+        wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${SDK_VER}/zephyr-sdk-${SDK_VER}_linux-x86_64.tar.xz
+        tar -xJf zephyr-sdk-${SDK_VER}_linux-x86_64.tar.xz
+        mv zephyr-sdk-${SDK_VER} zephyr-sdk
+        "$HOME/zephyr-sdk/setup.sh" -t all -h
+        echo "ZEPHYR_SDK_INSTALL_DIR=$HOME/zephyr-sdk" >> $GITHUB_ENV
 
     - name: Set up Zephyr environment
       run: |

--- a/.github/workflows/zephyr-build.yml
+++ b/.github/workflows/zephyr-build.yml
@@ -2,7 +2,7 @@ name: Zephyr RTOS Multi-Board Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
## Description

This PR fixes Zephyr CI builds across multiple boards and adds a separate CMake workflow for non‑Zephyr components.

Key updates:
- Use qualified ESP32‑S3 board target: `esp32s3_devkitc/esp32s3/procpu`
- Install Zephyr SDK (0.16.5) and export `ZEPHYR_SDK_INSTALL_DIR`
- Install `esptool>=5.0.2` and run `west packages pip --install`
- Export `PATH`/`ZEPHYR_BASE` via `$GITHUB_PATH`/`$GITHUB_ENV`
- Sanitize artifact names (no slashes)
- Run CI on any branch push; PRs target `main`
- Keep release gated to push on `main`
- Add CMake workflow for non‑Zephyr components

## Checklist
<!-- Make sure the PR is ready for review. -->

- [ ] Code follows the project’s style guidelines  
- [ ] Workflows named clearly and documented where needed  
- [ ] CI green on this branch (`kamila/TA/zephyr-build`)  
- [ ] Artifacts uploaded for all boards  
- [ ] QEMU test passes with 30s timeout  
- [ ] Release remains gated to push on `main`  
- [ ] Reviewers added (CI owner, Zephyr domain owner)  
- [ ] Labels added (`ci`, `zephyr`, `build`, `enhancement`)  
