### PR TITLE
Evin/tn/stm32 devicetree

### DIFF
--- a/test_node/app/boards/nucleo_h563zi.overlay
+++ b/test_node/app/boards/nucleo_h563zi.overlay
@@ -1,0 +1,18 @@
+/ {
+    aliases {
+        i2c-lidar = &i2c1;
+        i2c-imu = &i2c2;
+    };
+};
+
+&i2c1 {
+    status = "okay";
+    pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+    pinctrl-names = "default";
+};
+
+&i2c2 {
+    status = "okay";
+    pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
+    pinctrl-names = "default";
+};

--- a/test_node/app/src/threads/sensor_emulation.c
+++ b/test_node/app/src/threads/sensor_emulation.c
@@ -3,7 +3,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/i2c.h>
 
-static const struct device *bus = DEVICE_DT_GET(DT_NODELABEL(i2c1));
+static const struct device *i2c_lidar = DEVICE_DT_GET(DT_ALIAS(i2c_lidar));
+static const struct device *i2c_imu = DEVICE_DT_GET(DT_ALIAS(i2c_imu));
 static char last_byte;
 
 // register logging module
@@ -133,12 +134,12 @@ void sensor_emulation_init() {
 		.callbacks = &sample_target_callbacks,
 	};
 
-	if (i2c_target_register(bus, &lidar_cfg) < 0) {
+	if (i2c_target_register(i2c_lidar, &lidar_cfg) < 0) {
 		printk("Failed to register target\n");
         return;
 	}
 
-    if (i2c_target_register(bus, &imu_cfg) < 0) {
+    if (i2c_target_register(i2c_imu, &imu_cfg) < 0) {
 		printk("Failed to register target\n");
         return;
 	}

--- a/test_node/justfile
+++ b/test_node/justfile
@@ -44,8 +44,9 @@ build-nucleo: _verify_workspace clean
     -b "{{NUCLEO_BOARD}}" \
     -d build \
     app \
-    {{CMAKE_CACHE_ARGS}}
-  #* NOT ADDING OVERLAY BECAUSE .DTSI FILE "zephyr/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi" ALREADY ENABLES SPI & I2C    
+    {{CMAKE_CACHE_ARGS}} \
+    -DEXTRA_DTC_OVERLAY_FILE="{{justfile_directory()}}/app/boards/nucleo_h563zi.overlay"
+
 # ------------------
 #  ESP32-S3
 # ------------------


### PR DESCRIPTION
## Description
Link to Issue: [here](https://github.com/embedded-purdue/slayterHIL/issues/131)
Added the base i2c devicetree config with aliases for both the IMU and Lidar. Lidar is on SCL/SDA PB8/PB9 (i2c1) and IMU is on SCL/SDA PF1/PF0 (i2c2), which are both on zio header (i2c1 is on D14/15 on CN7 and i2c2 is on D68/69 on CN9). Also added the DT file to the just command and updated the i2c target config in the sensor thread.

## Additional Notes (mostly just a reference for me if i need it)
i2c1/2 default configuration
```
i2c1: i2c@40005400 {
	compatible = "st,stm32-i2c-v2";
	clock-frequency = <I2C_BITRATE_STANDARD>;
	#address-cells = <1>;
	#size-cells = <0>;
	reg = <0x40005400 0x400>;
	clocks = <&rcc STM32_CLOCK(APB1, 21)>;
	interrupts = <51 0>, <52 0>;
	interrupt-names = "event", "error";
	status = "disabled";
};

i2c2: i2c@40005800 {
	compatible = "st,stm32-i2c-v2";
	clock-frequency = <I2C_BITRATE_STANDARD>;
	#address-cells = <1>;
	#size-cells = <0>;
	reg = <0x40005800 0x400>;
	clocks = <&rcc STM32_CLOCK(APB1, 22)>;
	interrupts = <53 0>, <54 0>;
	interrupt-names = "event", "error";
	status = "disabled";
};
```
default pinctrl definitions:
```
/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
        pinmux = <STM32_PINMUX('B', 8, AF4)>;
        bias-pull-up;
        drive-open-drain;
};
/omit-if-no-ref/ i2c2_scl_pf1: i2c2_scl_pf1 {
        pinmux = <STM32_PINMUX('F', 1, AF4)>;
        bias-pull-up;
        drive-open-drain;
};

/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
        pinmux = <STM32_PINMUX('B', 9, AF4)>;
        bias-pull-up;
        drive-open-drain;
};
/omit-if-no-ref/ i2c2_sda_pf0: i2c2_sda_pf0 {
        pinmux = <STM32_PINMUX('F', 0, AF4)>;
        bias-pull-up;
        drive-open-drain;
};
```

## Checklist

- [x] Code follows the project’s style guidelines  
- [x] Code compiles with just build-nucleo
---
