### PR TITLE
fixed the scope on i2c configs

### DIFF
--- a/test_node/app/src/threads/sensor_emulation.c
+++ b/test_node/app/src/threads/sensor_emulation.c
@@ -163,23 +163,22 @@ static void sensor_emulation_thread(void *, void *, void *) {
 K_THREAD_STACK_DEFINE(sensor_emulation_stack, SENSOR_EMULATION_STACK_SIZE);
 struct k_thread sensor_emulation_data;
 
+struct i2c_target_config lidar_cfg = {
+    .address = LIDAR_ADDRESS,
+    .callbacks = &sample_target_callbacks,
+};
+
+struct i2c_target_config imu_cfg = {
+    .address = IMU_ADDRESS,
+    .callbacks = &sample_target_callbacks,
+};
+
 // Initialize and start thread
 void sensor_emulation_init() {
     // dummy printing for sanity
     LOG_INF("Sensor init\n");
 
     // Any initialization
-
-    struct i2c_target_config lidar_cfg = {
-		.address = LIDAR_ADDRESS,
-		.callbacks = &sample_target_callbacks,
-	};
-
-    struct i2c_target_config imu_cfg = {
-		.address = IMU_ADDRESS,
-		.callbacks = &sample_target_callbacks,
-	};
-
 	if (i2c_target_register(i2c_lidar, &lidar_cfg) < 0) {
 		printk("Failed to register target\n");
         return;


### PR DESCRIPTION
## Description
fixed the scope on i2c configs in emulation thread. overlooked this earlier, but the example in zephyr's repo has the configs in the main scope, which might work for the specific driver they are using, but for stm32 driver that copies the pointer, when main returns the config in the stm32 i2c driver becomes garbage and it doesn't work
